### PR TITLE
XB9-429 : Upstream xb9 specific changes to github repo

### DIFF
--- a/config/cr-deviceprofile_embedded.xml
+++ b/config/cr-deviceprofile_embedded.xml
@@ -28,9 +28,11 @@
 	<component>
 		<name>com.cisco.spvtg.ccsp.psm</name> <version>1</version>
 	</component>
+<?ifndef NO_MTA_FEATURE_SUPPORT?>
 	<component>
 		<name>com.cisco.spvtg.ccsp.mta</name> <version>1</version>
 	</component> 
+<?endif?>
 	<component>
 		<name>com.cisco.spvtg.ccsp.cm</name> <version>1</version>
 	</component>	 

--- a/source/cr-ethwan-deviceprofile.xml
+++ b/source/cr-ethwan-deviceprofile.xml
@@ -28,9 +28,11 @@
 	<component>
 		<name>com.cisco.spvtg.ccsp.psm</name> <version>1</version>
 	</component>
+<?ifndef NO_MTA_FEATURE_SUPPORT?>
 	<component>
 		<name>com.cisco.spvtg.ccsp.mta</name> <version>1</version>
 	</component>
+<?endif?>
 	<component>
 		<name>com.cisco.spvtg.ccsp.pam</name> <version>1</version>
 	</component>


### PR DESCRIPTION
Reason for change: Added flag to remove MTA registration from component-registry
Test Procedure: Build and verify
Risks: None
Priority: P1