### PR TITLE
XER10-2589: WEBCONFIG is working only after 8minutes in FR case

### DIFF
--- a/source/CCSP_CR/ccsp_cr_profile.c
+++ b/source/CCSP_CR/ccsp_cr_profile.c
@@ -98,6 +98,11 @@
 #define CCSP_CR_ETHWAN_DEVICE_PROFILE_XML_FILE      CCSP_CR_DEVICE_PROFILE_XML_LOCATION CCSP_CR_ETHWAN_DEVICE_PROFILE_XML_FILENAME
 
 #define CCSP_ETHWAN_ENABLE "/nvram/ETHWAN_ENABLE"
+#if defined(_SCER11BEL_PRODUCT_REQ_)
+#define CCSP_USE_ETHWAN_PROFILE 1
+#else
+#define CCSP_USE_ETHWAN_PROFILE 0
+#endif
 
 /**********************************************************************
 
@@ -140,7 +145,7 @@ CcspCrLoadDeviceProfile
     PCCSP_COMPONENT_INFO            pCompInfo          = (PCCSP_COMPONENT_INFO)NULL;
 
     /* load from the file */
-    if (access(CCSP_ETHWAN_ENABLE, F_OK) == 0)
+    if (CCSP_USE_ETHWAN_PROFILE || access(CCSP_ETHWAN_ENABLE, F_OK) == 0)
     {
         pFileHandle = AnscOpenFile
         (


### PR DESCRIPTION
Reason for change: Added XER10 product flag to always use ethwan-device profiile
Test Procedure: Load the build and ensure the ethwan-device profile is being used.
                            Process should be started without any delay
Priority: P1