### PR TITLE
XER10-2589: WEBCONFIG is working only after 8minutes in FR case

### DIFF
--- a/source/CCSP_CR/ccsp_cr_profile.c
+++ b/source/CCSP_CR/ccsp_cr_profile.c
@@ -98,11 +98,6 @@
 #define CCSP_CR_ETHWAN_DEVICE_PROFILE_XML_FILE      CCSP_CR_DEVICE_PROFILE_XML_LOCATION CCSP_CR_ETHWAN_DEVICE_PROFILE_XML_FILENAME
 
 #define CCSP_ETHWAN_ENABLE "/nvram/ETHWAN_ENABLE"
-#if defined(_SCER11BEL_PRODUCT_REQ_)
-#define CCSP_USE_ETHWAN_PROFILE 1
-#else
-#define CCSP_USE_ETHWAN_PROFILE 0
-#endif
 
 /**********************************************************************
 
@@ -145,7 +140,7 @@ CcspCrLoadDeviceProfile
     PCCSP_COMPONENT_INFO            pCompInfo          = (PCCSP_COMPONENT_INFO)NULL;
 
     /* load from the file */
-    if (CCSP_USE_ETHWAN_PROFILE || access(CCSP_ETHWAN_ENABLE, F_OK) == 0)
+    if (access(CCSP_ETHWAN_ENABLE, F_OK) == 0)
     {
         pFileHandle = AnscOpenFile
         (

--- a/source/CrSsp/ssp_rbus.c
+++ b/source/CrSsp/ssp_rbus.c
@@ -49,6 +49,12 @@
 #define CCSP_ETHWAN_ENABLE "/nvram/ETHWAN_ENABLE"
 #define CCSP_CR_ETHWAN_DEVICE_PROFILE_XML_FILE "cr-ethwan-deviceprofile.xml"
 #define CCSP_CR_DEVICE_PROFILE_XML_FILE "cr-deviceprofile.xml"
+#define CCSP_ETHWAN_ENABLE "/nvram/ETHWAN_ENABLE"
+#if defined(_SCER11BEL_PRODUCT_REQ_)
+#define CCSP_USE_ETHWAN_PROFILE 1
+#else
+#define CCSP_USE_ETHWAN_PROFILE 0
+#endif
 
 #define ERROR_CHECK(CMD) \
 do \
@@ -325,7 +331,7 @@ static int crData_LoadRegistry(crData_t cr)
     xmlChar* name = NULL, * version = NULL, * Event = NULL, * dep = NULL;
     const char* fileName = NULL;
 
-    if(access(CCSP_ETHWAN_ENABLE, F_OK) == 0)
+    if(CCSP_USE_ETHWAN_PROFILE || (access(CCSP_ETHWAN_ENABLE, F_OK) == 0))
         fileName = CCSP_CR_ETHWAN_DEVICE_PROFILE_XML_FILE;
     else
         fileName = CCSP_CR_DEVICE_PROFILE_XML_FILE;

--- a/source/CrSsp/ssp_rbus.c
+++ b/source/CrSsp/ssp_rbus.c
@@ -49,7 +49,6 @@
 #define CCSP_ETHWAN_ENABLE "/nvram/ETHWAN_ENABLE"
 #define CCSP_CR_ETHWAN_DEVICE_PROFILE_XML_FILE "cr-ethwan-deviceprofile.xml"
 #define CCSP_CR_DEVICE_PROFILE_XML_FILE "cr-deviceprofile.xml"
-#define CCSP_ETHWAN_ENABLE "/nvram/ETHWAN_ENABLE"
 #if defined(_SCER11BEL_PRODUCT_REQ_)
 #define CCSP_USE_ETHWAN_PROFILE 1
 #else


### PR DESCRIPTION
Reason for change: Enforcing XER10 to use ethwan device profile always
Test Procedure: Check whether CR loads ethwan profile and webconfig should start without any delay
Priority: P1

Signed-off-by: Jayashree <jayashree_M@comcast.com>